### PR TITLE
Customize Dashboard Header with CHIQUI VIM

### DIFF
--- a/lua/plugins/user.lua
+++ b/lua/plugins/user.lua
@@ -1,5 +1,3 @@
-if true then return {} end -- WARN: REMOVE THIS LINE TO ACTIVATE THIS FILE
-
 -- You can also add or configure plugins by creating files in this `plugins/` folder
 -- PLEASE REMOVE THE EXAMPLES YOU HAVE NO INTEREST IN BEFORE ENABLING THIS FILE
 -- Here are some examples:
@@ -25,17 +23,17 @@ return {
       dashboard = {
         preset = {
           header = table.concat({
-            " █████  ███████ ████████ ██████   ██████ ",
-            "██   ██ ██         ██    ██   ██ ██    ██",
-            "███████ ███████    ██    ██████  ██    ██",
-            "██   ██      ██    ██    ██   ██ ██    ██",
-            "██   ██ ███████    ██    ██   ██  ██████ ",
+            " ██████ ██   ██ ██  ██████  ██    ██ ██",
+            "██      ██   ██ ██ ██    ██ ██    ██ ██",
+            "██      ███████ ██ ██    ██ ██    ██ ██",
+            "██      ██   ██ ██ ██    ██ ██    ██ ██",
+            " ██████ ██   ██ ██  ██████   ██████  ██",
             "",
-            "███    ██ ██    ██ ██ ███    ███",
-            "████   ██ ██    ██ ██ ████  ████",
-            "██ ██  ██ ██    ██ ██ ██ ████ ██",
-            "██  ██ ██  ██  ██  ██ ██  ██  ██",
-            "██   ████   ████   ██ ██      ██",
+            "██    ██ ██ ███    ███",
+            "██    ██ ██ ████  ████",
+            "██    ██ ██ ██ ████ ██",
+            " ██  ██  ██ ██  ██  ██",
+            "  ████   ██ ██      ██",
           }, "\n"),
         },
       },


### PR DESCRIPTION
## Customize Dashboard Header

This PR customizes the Neovim dashboard startup screen by replacing the default "ASTRO NVIM" ASCII art with a custom "CHIQUI VIM" header.

### Changes
- Updated `lua/plugins/user.lua` with custom ASCII art header
- Enabled the dashboard customization by removing the early return statement

### Preview
The new startup screen now displays:
```
 ██████ ██   ██ ██  ██████  ██    ██ ██
██      ██   ██ ██ ██    ██ ██    ██ ██
██      ███████ ██ ██    ██ ██    ██ ██
██      ██   ██ ██ ██    ██ ██    ██ ██
 ██████ ██   ██ ██  ██████   ██████  ██

██    ██ ██ ███    ███
██    ██ ██ ████  ████
██    ██ ██ ██ ████ ██
 ██  ██  ██ ██  ██  ██
  ████   ██ ██      ██
```
