### PR TITLE
Enable git inline blame on open

### DIFF
--- a/lua/plugins/gitsigns.lua
+++ b/lua/plugins/gitsigns.lua
@@ -1,0 +1,6 @@
+return {
+  "lewis6991/gitsigns.nvim",
+  opts = {
+    current_line_blame = true,
+  },
+}


### PR DESCRIPTION
When opening, blame current line is enabled